### PR TITLE
Current blacktop/bro:elastic does not support ES 6.x

### DIFF
--- a/docs/elastic.md
+++ b/docs/elastic.md
@@ -3,7 +3,7 @@ Integrate with the Elastic Stack
 
 ```bash
 $ wget https://github.com/blacktop/docker-bro/raw/master/pcap/heartbleed.pcap
-$ docker run -d --name elasticsearch -p 9200:9200 blacktop/elasticsearch
+$ docker run -d --name elasticsearch -p 9200:9200 blacktop/elasticsearch:5.6
 $ docker run -d --name kibana --link elasticsearch -p 5601:5601 blacktop/kibana
 $ docker run -it --rm -v `pwd`:/pcap --link elasticsearch \
              blacktop/bro:elastic -r heartbleed.pcap local "Site::local_nets += { 192.168.11.0/24 }"
@@ -32,7 +32,7 @@ Click the [Discover](http://localhost:5601/app/kibana#/discover) tab and filter 
 ### Watch a folder
 
 ```bash
-$ docker run -d --name elstack -p 80:80 -p 9200:9200 blacktop/elastic-stack
+$ docker run -d --name elstack -p 80:80 -p 9200:9200 blacktop/elastic-stack:5.6
 $ docker run -it --rm -v `pwd`:/pcap --link elasticsearch blacktop/bro:elastic bro-watch
 
 # assuming you are using Docker For Mac.             


### PR DESCRIPTION
elastic/template.json should start follow 6.x rules.